### PR TITLE
Add missing dev-dependency "gzip-size-cli".

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "documentation": "^4.0.0",
     "eslint": "^4.16.0",
     "eslint-config-developit": "^1.1.1",
+    "gzip-size-cli": "^2.1.0",
     "jest": "^22.1.4",
     "karma": "^2.0.0",
     "karma-chai-sinon": "^0.1.5",


### PR DESCRIPTION
Added dev-dependency `gzip-size-cli`.
You are using the cli command in the npm `size` script.
So this script (and therefore the `build` script) fails if it's run without `gzip-size-cli` installed.