### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Given a Web Worker instance, sets up RPC-based synchronization with a WorkerStor
 ```javascript
 import createStore from 'stockroom'
 import StoreWorker from 'worker-loader!./store.worker'
-let store = createStore(new StoreWorker)
+let store = createStore(new StoreWorker())
 ```
 
 Returns **Store** synchronizedStore - a mock unistore store instance sitting in front of the worker store.
@@ -99,12 +99,12 @@ Returns **Store** synchronizedStore - a mock unistore store instance sitting in 
 #### module:stockroom/inline
 
 Used to run your whole store on the main thread.
-Useful non-worker environments or as a fallback.
+Useful for non-worker environments or as a fallback.
 
 ##### createInlineStore
 
 For SSR/prerendering, pass your exported worker store through this enhancer
- to make an inline synchronous version that runs in the same thread.
+to make an inline synchronous version that runs in the same thread.
 
 **Parameters**
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,12 @@ let stockroom; // eslint-disable-line
 
 /** Given a Web Worker instance, sets up RPC-based synchronization with a WorkerStore running within it.
  *	@memberof module:stockroom
- *  @param {Worker} worker		An instantiated Web Worker (eg: `new Worker('./store.worker.js')`)
- *  @returns {Store} synchronizedStore - a mock unistore store instance sitting in front of the worker store.
+ *	@param {Worker} worker		An instantiated Web Worker (eg: `new Worker('./store.worker.js')`)
+ *	@returns {Store} synchronizedStore - a mock unistore store instance sitting in front of the worker store.
  *	@example
  *	import createStore from 'stockroom'
  *	import StoreWorker from 'worker-loader!./store.worker'
- *	let store = createStore(new StoreWorker)
+ *	let store = createStore(new StoreWorker())
  */
 export default function createStore(worker) {
 	let listeners = [],

--- a/src/inline.js
+++ b/src/inline.js
@@ -1,17 +1,17 @@
 /** Used to run your whole store on the main thread.
- *	Useful non-worker environments or as a fallback.
+ *	Useful for non-worker environments or as a fallback.
  *	@name module:stockroom/inline
  */
 let inline; // eslint-disable-line
 
 /** For SSR/prerendering, pass your exported worker store through this enhancer
- *  to make an inline synchronous version that runs in the same thread.
+ *	to make an inline synchronous version that runs in the same thread.
  *	@memberof module:stockroom/inline
- *  @param {WorkerStore} workerStore	The exported `store` instance that would have been invoked in a Worker
- *  @returns {Store} inlineStore - a unistore instance with centralized actions
+ *	@param {WorkerStore} workerStore	The exported `store` instance that would have been invoked in a Worker
+ *	@returns {Store} inlineStore - a unistore instance with centralized actions
  *	@example
  *	let store
- *	if (SUPPORTS_WEB_WORKERS) {
+ *	if (SUPPORTS_WEB_WORKERS === false) {
  *		let createStore = require('stockroom/inline')
  *		store = createStore(require('./store.worker'))
  *	}


### PR DESCRIPTION
- Added parens to [src/index.js:16](https://github.com/developit/stockroom/pull/24/files#diff-1fdf421c05c1140f6d71444ea2b27638R16)
- Changed some spaces to tabs, according to [.editorconfig](https://github.com/developit/stockroom/blob/master/.editorconfig#L4)
- Inverted condition in [src/inline.js:14](https://github.com/developit/stockroom/pull/24/files#diff-b605b46e4de9a26c21c1075e73e7650fR14) to align it with what is already in the [README](https://github.com/developit/stockroom/blame/master/README.md#L117)